### PR TITLE
Add FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ enabled.
 Feel free to edit this file or provide your own when running the script.
 
 
+
+## API Server
+
+Run the FastAPI server to expose strategy endpoints:
+
+```bash
+uvicorn server.app:app --reload
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ matplotlib
 PyYAML
 rich
 loguru
+fastapi
+uvicorn

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from ta_engine.data import load_price_data
+from ta_engine.strategies import run_strategy
+
+app = FastAPI()
+
+
+class StrategyRequest(BaseModel):
+    filepath: str
+    config: dict
+
+
+@app.post("/run_strategy")
+def run_strategy_api(req: StrategyRequest):
+    df = load_price_data(req.filepath)
+    result = run_strategy(df, req.config)
+    return result.to_dict(orient="records")
+


### PR DESCRIPTION
## Summary
- create `server` package with FastAPI app
- expose `/run_strategy` endpoint for running strategies
- document running the API
- include `fastapi` and `uvicorn` in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m pip check`
- `python -m py_compile server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6880e92eb3f88328a1fbd9b133810fe8