### PR TITLE
Add live data support to run_strategy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ rich
 loguru
 fastapi
 uvicorn
+ccxt

--- a/server/app.py
+++ b/server/app.py
@@ -1,19 +1,42 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 from ta_engine.data import load_price_data
+from ta_engine.live_data import fetch_ohlcv
 from ta_engine.strategies import run_strategy
 
 app = FastAPI()
 
 
 class StrategyRequest(BaseModel):
-    filepath: str
+    filepath: str | None = None
     config: dict
+    symbol: str | None = None
+    exchange: str | None = None
+    resolution: str | None = "1h"
+    limit: int | None = 200
 
 
 @app.post("/run_strategy")
 def run_strategy_api(req: StrategyRequest):
-    df = load_price_data(req.filepath)
+    if req.symbol and req.exchange:
+        live_df = fetch_ohlcv(
+            req.symbol,
+            req.exchange,
+            timeframe=req.resolution or "1h",
+            limit=req.limit or 200,
+        )
+        df = live_df.rename(
+            columns={
+                "open": "Open",
+                "high": "High",
+                "low": "Low",
+                "close": "Close",
+                "volume": "Volume",
+                "date": "Date",
+            }
+        ).set_index("Date")
+    else:
+        df = load_price_data(req.filepath)
     result = run_strategy(df, req.config)
     return result.to_dict(orient="records")
 

--- a/ta_engine/live_data.py
+++ b/ta_engine/live_data.py
@@ -1,0 +1,11 @@
+import ccxt
+import pandas as pd
+
+
+def fetch_ohlcv(symbol: str, exchange_name: str, timeframe: str = "1h", limit: int = 200) -> pd.DataFrame:
+    exchange_class = getattr(ccxt, exchange_name)
+    exchange = exchange_class()
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+    df = pd.DataFrame(ohlcv, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
+    return df


### PR DESCRIPTION
## Summary
- add `live_data.py` module with OHLCV fetch utility using CCXT
- update API model to accept live data parameters
- fetch live data when `symbol`/`exchange` provided, else load CSV
- include `ccxt` in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile ta_engine/live_data.py server/app.py`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_6880ec9945088328be8598d83ebd2d3f