### PR TITLE
Enhance live data error handling

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -18,25 +18,32 @@ class StrategyRequest(BaseModel):
 
 @app.post("/run_strategy")
 def run_strategy_api(req: StrategyRequest):
-    if req.symbol and req.exchange:
-        live_df = fetch_ohlcv(
-            req.symbol,
-            req.exchange,
-            timeframe=req.resolution or "1h",
-            limit=req.limit or 200,
-        )
-        df = live_df.rename(
-            columns={
-                "open": "Open",
-                "high": "High",
-                "low": "Low",
-                "close": "Close",
-                "volume": "Volume",
-                "date": "Date",
-            }
-        ).set_index("Date")
-    else:
-        df = load_price_data(req.filepath)
-    result = run_strategy(df, req.config)
-    return result.to_dict(orient="records")
+    try:
+        if req.symbol and req.exchange:
+            live_df = fetch_ohlcv(
+                req.symbol,
+                req.exchange,
+                timeframe=req.resolution or "1h",
+                limit=req.limit or 200,
+            )
+            df = (
+                live_df.rename(
+                    columns={
+                        "open": "Open",
+                        "high": "High",
+                        "low": "Low",
+                        "close": "Close",
+                        "volume": "Volume",
+                        "date": "Date",
+                    }
+                ).set_index("Date")
+            )
+        else:
+            df = load_price_data(req.filepath)
+
+        result = run_strategy(df, req.config)
+        return result.to_dict(orient="records")
+
+    except Exception as e:
+        return {"error": str(e)}
 

--- a/ta_engine/live_data.py
+++ b/ta_engine/live_data.py
@@ -1,11 +1,33 @@
+from ccxt.base.errors import ExchangeNotAvailable
+import requests
+
 import ccxt
 import pandas as pd
 
 
 def fetch_ohlcv(symbol: str, exchange_name: str, timeframe: str = "1h", limit: int = 200) -> pd.DataFrame:
-    exchange_class = getattr(ccxt, exchange_name)
-    exchange = exchange_class()
-    ohlcv = exchange.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
-    df = pd.DataFrame(ohlcv, columns=["timestamp", "open", "high", "low", "close", "volume"])
-    df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
-    return df
+    try:
+        exchange_class = getattr(ccxt, exchange_name)
+        exchange = exchange_class()
+
+        exchange.load_markets()
+        ohlcv = exchange.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+        df = pd.DataFrame(
+            ohlcv,
+            columns=["timestamp", "open", "high", "low", "close", "volume"],
+        )
+        df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
+
+        if df.empty or df.shape[0] < 10:
+            raise ValueError(
+                f"Received insufficient data from {exchange_name} for {symbol} ({df.shape[0]} rows)"
+            )
+
+        return df
+
+    except ExchangeNotAvailable as e:
+        raise ValueError(f"Exchange '{exchange_name}' is not available: {str(e)}")
+    except requests.exceptions.HTTPError as e:
+        raise ValueError(f"HTTP error when accessing {exchange_name}: {str(e)}")
+    except Exception as e:
+        raise ValueError(f"Error fetching data from {exchange_name}: {str(e)}")


### PR DESCRIPTION
## Summary
- handle missing/invalid data when fetching OHLCV
- surface HTTP/exchange errors in fetch_ohlcv
- return errors from `/run_strategy` endpoint instead of crashing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880f175b710832890f8c806f006c17e