### PR TITLE
Add CryptoPanic news endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+CRYPTOPANIC_API_KEY=demo

--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ Run the FastAPI server to expose strategy endpoints:
 ```bash
 uvicorn server.app:app --reload
 ```
+
+### News endpoint
+
+The `/news` route aggregates recent headlines from CryptoPanic for BTC and
+ETH.  Ensure a `CRYPTOPANIC_API_KEY` is available in a `.env` file before
+running:
+
+```bash
+curl http://localhost:8000/news
+```

--- a/core/news.py
+++ b/core/news.py
@@ -1,0 +1,53 @@
+import os
+import json
+from typing import List, Dict
+
+import requests
+
+
+_DEF_ENV_FILE = ".env"
+
+
+def _load_api_key() -> str | None:
+    """Load CryptoPanic API key from environment or .env file."""
+    key = os.environ.get("CRYPTOPANIC_API_KEY")
+    if key:
+        return key
+    if os.path.exists(_DEF_ENV_FILE):
+        with open(_DEF_ENV_FILE) as f:
+            for line in f:
+                if line.strip().startswith("CRYPTOPANIC_API_KEY="):
+                    return line.strip().split("=", 1)[1]
+    return None
+
+
+def fetch_latest_news(limit: int = 20) -> List[Dict]:
+    """Fetch latest crypto news from CryptoPanic."""
+    key = _load_api_key()
+    if not key:
+        raise ValueError("CryptoPanic API key not found in environment or .env")
+
+    url = "https://cryptopanic.com/api/v1/posts/"
+    params = {
+        "auth_token": key,
+        "currencies": "BTC,ETH",
+        "filter": "hot",
+    }
+
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+
+    headlines = []
+    for post in data.get("results", [])[:limit]:
+        headlines.append(
+            {
+                "source": post.get("source", {}).get("title") or post.get("source"),
+                "title": post.get("title"),
+                "url": post.get("url"),
+                "published_at": post.get("published_at"),
+                "tags": [c.get("code") for c in post.get("currencies", [])],
+            }
+        )
+
+    return headlines

--- a/debug_news.py
+++ b/debug_news.py
@@ -1,0 +1,13 @@
+import requests
+
+URL = "http://localhost:8000/news"
+
+if __name__ == "__main__":
+    try:
+        resp = requests.get(URL, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        for item in data[:3]:
+            print(f"{item['published_at']} - {item['title']}")
+    except Exception as e:
+        print("Error:", e)

--- a/server/app.py
+++ b/server/app.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from core.news import fetch_latest_news
 from ta_engine.data import load_price_data
 from ta_engine.live_data import fetch_ohlcv
 from ta_engine.strategies import run_strategy
@@ -53,6 +54,15 @@ def run_strategy_api(req: StrategyRequest):
         result = run_strategy(df, req.config)
         return result.to_dict(orient="records")
 
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@app.get("/news")
+def get_news():
+    """Return recent news headlines from CryptoPanic."""
+    try:
+        return fetch_latest_news(20)
     except Exception as e:
         return {"error": str(e)}
 


### PR DESCRIPTION
## Summary
- add `/news` endpoint powered by CryptoPanic
- implement helper in `core/news.py` for API requests
- document news endpoint in README
- include debug script to call `/news`
- store demo API key in `.env`

## Testing
- `python debug_news.py` *(fails: 403 Forbidden from cryptopanic.com)*

------
https://chatgpt.com/codex/tasks/task_e_68815bca4ef48328ba6a61090cb13be3