### PR TITLE
Add composite signal summary endpoint

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -1,0 +1,112 @@
+import pandas as pd
+from typing import Dict, Any, List, Tuple
+
+from .indicators import rsi, macd, bollinger
+
+
+Signal = Dict[str, Any]
+
+
+def _rsi_signal(df: pd.DataFrame, window: int = 14) -> Signal:
+    df = rsi(df.copy(), window=window)
+    value = df[f"RSI_{window}"].iloc[-1]
+    if value < 30:
+        signal = "long"
+        confidence = min((30 - value) / 30, 1.0)
+    elif value > 70:
+        signal = "short"
+        confidence = min((value - 70) / 30, 1.0)
+    else:
+        signal = "neutral"
+        confidence = 1 - abs(value - 50) / 50
+    return {"method": "RSI", "signal": signal, "confidence": round(float(confidence), 2)}
+
+
+def _macd_signal(df: pd.DataFrame, fast: int = 12, slow: int = 26, signal: int = 9) -> Signal:
+    df = macd(df.copy(), fast=fast, slow=slow, signal=signal)
+    hist = df["MACD_hist"].iloc[-1]
+    max_hist = df["MACD_hist"].abs().max()
+    max_hist = max_hist if max_hist != 0 else 1
+    if hist > 0:
+        sig = "long"
+        confidence = min(abs(hist) / max_hist, 1.0)
+    elif hist < 0:
+        sig = "short"
+        confidence = min(abs(hist) / max_hist, 1.0)
+    else:
+        sig = "neutral"
+        confidence = 0.0
+    return {"method": "MACD", "signal": sig, "confidence": round(float(confidence), 2)}
+
+
+def _bollinger_signal(df: pd.DataFrame, window: int = 20, std_dev: float = 2.0) -> Signal:
+    df = bollinger(df.copy(), window=window, n_sigma=std_dev)
+    close = df["Close"].iloc[-1]
+    upper = df[f"BB_U_{window}"].iloc[-1]
+    lower = df[f"BB_L_{window}"].iloc[-1]
+    width = upper - lower if upper != lower else 1
+    if close < lower:
+        sig = "long"
+        confidence = min((lower - close) / width, 1.0)
+    elif close > upper:
+        sig = "short"
+        confidence = min((close - upper) / width, 1.0)
+    else:
+        sig = "neutral"
+        mid = (upper + lower) / 2
+        confidence = 1 - abs(close - mid) / (width / 2)
+    return {"method": "Bollinger", "signal": sig, "confidence": round(float(confidence), 2)}
+
+
+def indicator_signals(df: pd.DataFrame, config: Dict[str, Any]) -> List[Signal]:
+    """Compute signals for each indicator defined in config."""
+    results: List[Signal] = []
+    if "rsi" in config:
+        window = config["rsi"].get("window", 14)
+        results.append(_rsi_signal(df, window=window))
+    if "macd" in config:
+        mc = config["macd"]
+        results.append(
+            _macd_signal(
+                df,
+                fast=mc.get("fast", 12),
+                slow=mc.get("slow", 26),
+                signal=mc.get("signal", 9),
+            )
+        )
+    if "bollinger" in config:
+        bc = config["bollinger"]
+        results.append(
+            _bollinger_signal(
+                df,
+                window=bc.get("window", 20),
+                std_dev=bc.get("std_dev", 2.0),
+            )
+        )
+    return results
+
+
+def _summarize(details: List[Signal]) -> Tuple[str, float]:
+    """Return overall signal and confidence from individual indicator signals."""
+    if not details:
+        return "neutral", 0.0
+
+    sign_map = {"long": 1, "short": -1, "neutral": 0}
+    weighted = sum(sign_map[d["signal"]] * d["confidence"] for d in details)
+    total_conf = sum(d["confidence"] for d in details)
+    if total_conf == 0:
+        return "neutral", 0.0
+    score = weighted / total_conf
+    if score > 0.1:
+        summary = "long"
+    elif score < -0.1:
+        summary = "short"
+    else:
+        summary = "neutral"
+    return summary, round(abs(score), 2)
+
+
+def timeframe_summary(df: pd.DataFrame, config: Dict[str, Any]) -> Dict[str, Any]:
+    details = indicator_signals(df, config)
+    summary, conf = _summarize(details)
+    return {"summary": summary, "confidence": conf, "details": details}

--- a/debug_summary.py
+++ b/debug_summary.py
@@ -1,0 +1,17 @@
+import requests
+import json
+
+payload = {
+    "symbol": "BTC/USDT",
+    "exchange": "binanceus",
+    "resolutions": {"short_term": "1h", "long_term": "4h"},
+    "indicators": {
+        "rsi": {"window": 14},
+        "macd": {"fast": 12, "slow": 26, "signal": 9},
+        "bollinger": {"window": 20, "std_dev": 2},
+    },
+}
+
+resp = requests.post("http://localhost:8000/summary_signal", json=payload)
+print("Status:", resp.status_code)
+print(json.dumps(resp.json(), indent=2))

--- a/server/app.py
+++ b/server/app.py
@@ -5,6 +5,7 @@ from ta_engine.data import load_price_data
 from ta_engine.live_data import fetch_ohlcv
 from ta_engine.strategies import run_strategy
 from core.indicators import compute_indicators
+from core.signals import timeframe_summary
 import numpy as np
 
 app = FastAPI()
@@ -23,6 +24,14 @@ class IndicatorRequest(BaseModel):
     symbol: str
     exchange: str
     resolution: str = "1h"
+    indicators: dict
+    limit: int | None = 200
+
+
+class SummarySignalRequest(BaseModel):
+    symbol: str
+    exchange: str
+    resolutions: dict
     indicators: dict
     limit: int | None = 200
 
@@ -55,6 +64,36 @@ def run_strategy_api(req: StrategyRequest):
         result = run_strategy(df, req.config)
         return result.to_dict(orient="records")
 
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@app.post("/summary_signal")
+def summary_signal(req: SummarySignalRequest):
+    try:
+        results = {}
+        for name, tf in req.resolutions.items():
+            live_df = fetch_ohlcv(
+                req.symbol,
+                req.exchange,
+                timeframe=tf,
+                limit=req.limit or 200,
+            )
+            df = (
+                live_df.rename(
+                    columns={
+                        "open": "Open",
+                        "high": "High",
+                        "low": "Low",
+                        "close": "Close",
+                        "volume": "Volume",
+                        "date": "Date",
+                    }
+                ).set_index("Date")
+            )
+            results[name] = timeframe_summary(df, req.indicators)
+
+        return results
     except Exception as e:
         return {"error": str(e)}
 


### PR DESCRIPTION
## Summary
- implement `core/signals` to convert indicators into simple trade signals
- expose new `/summary_signal` FastAPI route
- provide example `debug_summary.py` script

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6882585abf7c832887ec0ecf870ce3aa