### PR TITLE
Enable Loguru debug flag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ general:
   start_date: 2025-01-01
   end_date:   2025-01-31
   multi_tf:   true
+  debug: true
 
 single_tf:
   timeframes: ["1D", "1H", "15T"]

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,11 +1,11 @@
-"""Logging setup using Loguru with Rich formatting."""
+"""Logging setup using Loguru."""
 
+import sys
 from loguru import logger
-from rich.logging import RichHandler
 
 
-def init_logger(level: str = "INFO") -> None:
-    """Configure Loguru to use RichHandler."""
+def init_logger(debug: bool = False) -> None:
+    """Configure Loguru based on debug flag."""
     logger.remove()
-    logger.add(RichHandler(markup=True, rich_tracebacks=True), level=level)
+    logger.add(sys.stderr, level="DEBUG" if debug else "INFO")
 

--- a/core/signals.py
+++ b/core/signals.py
@@ -1,6 +1,8 @@
 import pandas as pd
 from typing import Dict, Any, List, Tuple
 
+from loguru import logger
+
 from .indicators import rsi, macd, bollinger
 
 
@@ -20,7 +22,9 @@ def _rsi_signal(df: pd.DataFrame, window: int = 14, debug: bool = False) -> Sign
         signal = "neutral"
         confidence = 0.5
     if debug:
-        print(f"RSI={value:.2f} → Signal={signal}, Confidence={confidence:.2f}")
+        logger.debug(
+            f"RSI={value:.2f} → Signal={signal}, Confidence={confidence:.2f}"
+        )
     return {"method": "RSI", "signal": signal, "confidence": round(float(confidence), 2)}
 
 
@@ -39,7 +43,9 @@ def _macd_signal(df: pd.DataFrame, fast: int = 12, slow: int = 26, signal: int =
         sig = "neutral"
         confidence = 0.0
     if debug:
-        print(f"MACD histogram={hist:.5f} → Signal={sig}, Confidence={confidence:.2f}")
+        logger.debug(
+            f"MACD histogram={hist:.5f} → Signal={sig}, Confidence={confidence:.2f}"
+        )
     return {"method": "MACD", "signal": sig, "confidence": round(float(confidence), 2)}
 
 
@@ -61,7 +67,9 @@ def _bollinger_signal(df: pd.DataFrame, window: int = 20, std_dev: float = 2.0, 
         confidence = max(1 - abs(close - mid) / (width / 2), 0.4)
         confidence = min(confidence, 0.6)
     if debug:
-        print(f"Close={close:.2f}, Lower={lower:.2f}, Upper={upper:.2f} → Signal={sig}, Confidence={confidence:.2f}")
+        logger.debug(
+            f"Close={close:.2f}, Lower={lower:.2f}, Upper={upper:.2f} → Signal={sig}, Confidence={confidence:.2f}"
+        )
     return {"method": "Bollinger", "signal": sig, "confidence": round(float(confidence), 2)}
 
 
@@ -118,7 +126,9 @@ def _summarize(details: List[Signal]) -> Tuple[str, float]:
     return summary, round(abs(score), 2)
 
 
-def timeframe_summary(df: pd.DataFrame, config: Dict[str, Any]) -> Dict[str, Any]:
-    details = indicator_signals(df, config)
+def timeframe_summary(
+    df: pd.DataFrame, config: Dict[str, Any], debug: bool = False
+) -> Dict[str, Any]:
+    details = indicator_signals(df, config, debug=debug)
     summary, conf = _summarize(details)
     return {"summary": summary, "confidence": conf, "details": details}

--- a/main.py
+++ b/main.py
@@ -25,23 +25,26 @@ def parse_args():
     return parser.parse_args()
 
 def main():
-    init_logger()
     console.print("[bold green]Starting analysis...[/bold green]")
     args = parse_args()
     # Load configuration
     with open(args.config, "r") as f:
         cfg = yaml.safe_load(f)
-    logger.info("Loaded config from {}", args.config)
+
     gen = cfg["general"]
     stf = cfg["single_tf"]
     mtf = cfg["multi_tf"]
+
+    init_logger(debug=gen.get("debug", False))
+    debug = gen.get("debug", False)
+    logger.info("Loaded config from {}", args.config)
 
     # Load and optionally filter data
     logger.info("Loading data range {start} to {end}", start=gen["start_date"], end=gen["end_date"])
     raw_df = load_price_data(gen["file"])
     raw_df = raw_df.loc[gen["start_date"] : gen["end_date"]]
 
-    result = run_strategy(raw_df, cfg)
+    result = run_strategy(raw_df, cfg, debug=debug)
 
     if gen.get("multi_tf"):
         # result is 15-minute dataframe with Equity column

--- a/ta_engine/strategies.py
+++ b/ta_engine/strategies.py
@@ -10,7 +10,7 @@ from core.methods.multi_mean_reversion import (
 from core.backtest import backtest_signals
 
 
-def run_strategy(df: pd.DataFrame, config: dict) -> pd.DataFrame:
+def run_strategy(df: pd.DataFrame, config: dict, debug: bool = False) -> pd.DataFrame:
     """Run trading strategy based on configuration."""
     if config.get("strategy") == "passthrough_only":
         return df[["timestamp", "Open", "High", "Low", "Close", "Volume"]].copy()


### PR DESCRIPTION
## Summary
- pipe signal debug logs through Loguru
- toggle logger verbosity with a debug flag
- expose debug param to strategies
- wire CLI to read `general.debug`

## Testing
- `python -m py_compile main.py core/signals.py core/logger.py ta_engine/strategies.py`
- `python main.py --config config.yaml > /tmp/main.log 2>&1 && tail -n 20 /tmp/main.log`

------
https://chatgpt.com/codex/tasks/task_e_6882844875d483288c64e3de74956753