### PR TITLE
Add API key protection and Render deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Run the FastAPI server to expose strategy endpoints:
 uvicorn server.app:app --reload
 ```
 
+All endpoints require an API key. Create a `.env` file alongside the
+application and define your keys:
+
+```bash
+API_KEY=your-secret-key
+CRYPTOPANIC_API_KEY=your-news-api-key
+```
+
 ### News endpoint
 
 The `/news` route aggregates recent headlines from CryptoPanic for BTC and

--- a/config.yaml
+++ b/config.yaml
@@ -21,3 +21,4 @@ multi_tf:
   zone_overbought:  70.0
   bb_window: 20
   bb_sigma:  2.5
+

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: ta-api
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn server.app:app --host 0.0.0.0 --port 10000
+    envVars:
+      - key: GPT_API_KEY
+        sync: false
+      - key: CRYPTOPANIC_API_KEY
+        sync: false
+      - key: API_KEY
+        sync: false
+

--- a/server/app.py
+++ b/server/app.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
+import os
 from core.news import fetch_latest_news
 from ta_engine.data import load_price_data
 from ta_engine.live_data import fetch_ohlcv
@@ -7,6 +8,27 @@ from ta_engine.strategies import run_strategy
 from core.indicators import compute_indicators
 from core.signals import timeframe_summary
 import numpy as np
+
+_ENV_FILE = ".env"
+
+
+def _read_env_var(key: str) -> str | None:
+    """Read a single variable from the local .env file."""
+    if os.path.exists(_ENV_FILE):
+        with open(_ENV_FILE) as f:
+            for line in f:
+                if line.strip().startswith(f"{key}="):
+                    return line.strip().split("=", 1)[1]
+    return None
+
+
+# Load API key once at startup
+API_KEY = os.getenv("API_KEY") or _read_env_var("API_KEY")
+
+
+def verify_api_key(x_api_key: str = Header(...)):
+    if not API_KEY or x_api_key != API_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
 app = FastAPI()
 
@@ -37,7 +59,8 @@ class SummarySignalRequest(BaseModel):
 
 
 @app.post("/run_strategy")
-def run_strategy_api(req: StrategyRequest):
+def run_strategy_api(req: StrategyRequest, x_api_key: str = Header(...)):
+    verify_api_key(x_api_key)
     try:
         if req.symbol and req.exchange:
             live_df = fetch_ohlcv(
@@ -69,7 +92,8 @@ def run_strategy_api(req: StrategyRequest):
 
 
 @app.post("/summary_signal")
-def summary_signal(req: SummarySignalRequest):
+def summary_signal(req: SummarySignalRequest, x_api_key: str = Header(...)):
+    verify_api_key(x_api_key)
     try:
         results = {}
         for name, tf in req.resolutions.items():
@@ -99,7 +123,8 @@ def summary_signal(req: SummarySignalRequest):
 
 
 @app.get("/news")
-def get_news():
+def get_news(x_api_key: str = Header(...)):
+    verify_api_key(x_api_key)
     """Return recent news headlines from CryptoPanic."""
     try:
         return fetch_latest_news(20)
@@ -108,7 +133,8 @@ def get_news():
 
 
 @app.post("/compute_indicators")
-def compute_indicators_api(req: IndicatorRequest):
+def compute_indicators_api(req: IndicatorRequest, x_api_key: str = Header(...)):
+    verify_api_key(x_api_key)
     try:
         live_df = fetch_ohlcv(
             req.symbol,


### PR DESCRIPTION
## Summary
- secure API routes using API key authentication
- add example environment variable instructions in README
- create render deployment file
- load API key from `.env` only once

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6882b27db5848328b07250bcfb9da2ac