### PR TITLE
Add preset registry and execution API

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI, Depends, Security, HTTPException, status
 from fastapi.security.api_key import APIKeyHeader
+from fastapi.responses import JSONResponse
+from typing import List
 import os
 from core.news import fetch_latest_news
 from ta_engine.data import load_price_data
@@ -10,6 +12,7 @@ from core.signals import timeframe_summary
 import numpy as np
 import pandas as pd
 from loguru import logger
+from .presets import PRESETS, Preset
 from .models import (
     SummarySignalRequest,
     SummarySignalResponse,
@@ -18,6 +21,9 @@ from .models import (
     RunStrategyRequest,
     RunStrategyResponse,
     OhlcvResponse,
+    PresetInfo,
+    PresetDetail,
+    PresetExecuteRequest,
 )
 
 _ENV_FILE = ".env"
@@ -234,6 +240,85 @@ def compute_indicators_api(req: ComputeIndicatorsRequest):
 
     except Exception as e:
         return {"error": str(e)}
+
+
+# Preset routes
+@app.get("/presets", response_model=List[PresetInfo], dependencies=[Depends(verify_api_key)])
+def list_presets():
+    """List available presets with brief descriptions and target endpoints."""
+    return [
+        PresetInfo(name=p.name, description=p.description, method=p.method, path=p.path)
+        for p in PRESETS.values()
+    ]
+
+
+@app.get(
+    "/presets/{name}",
+    response_model=PresetDetail,
+    dependencies=[Depends(verify_api_key)],
+)
+def get_preset(name: str):
+    """Return details for a specific preset, including default payload/params."""
+    p = PRESETS.get(name)
+    if not p:
+        return JSONResponse(status_code=404, content={"error": f"Preset '{name}' not found"})
+    return PresetDetail(
+        name=p.name,
+        description=p.description,
+        method=p.method,
+        path=p.path,
+        default_body=p.default_body,
+        default_params=p.default_params,
+    )
+
+
+@app.post("/presets/execute", dependencies=[Depends(verify_api_key)])
+def execute_preset(req: PresetExecuteRequest):
+    """Execute a preset by name. Overrides (if provided) are merged into default body/params."""
+    p = PRESETS.get(req.name)
+    if not p:
+        return JSONResponse(status_code=404, content={"error": f"Preset '{req.name}' not found"})
+
+    body = {**(p.default_body or {})}
+    params = {**(p.default_params or {})}
+    if req.overrides_body:
+        body.update(req.overrides_body)
+    if req.overrides_params:
+        params.update(req.overrides_params)
+
+    if p.execute_fn:
+        try:
+            return p.execute_fn({"body": body, "params": params})
+        except Exception as e:
+            return JSONResponse(status_code=400, content={"error": str(e)})
+
+    try:
+        if p.method == "GET" and p.path == "/ohlcv":
+            df = fetch_ohlcv(
+                params.get("symbol", "BTC/USDT"),
+                params.get("exchange", "binanceus"),
+                timeframe=params.get("resolution", "1h"),
+                limit=int(params.get("limit", 200)),
+                strict=False,
+            )
+            norm = normalize_prices_df(df, context=f"preset:{p.name}")
+            return norm.tail(int(params.get("limit", 200))).to_dict(orient="records")
+
+        if p.method == "GET" and p.path == "/news":
+            return get_news()
+
+        if p.method == "POST" and p.path == "/summary_signal":
+            return summary_signal(SummarySignalRequest(**body))
+
+        if p.method == "POST" and p.path == "/compute_indicators":
+            return compute_indicators_api(ComputeIndicatorsRequest(**body))
+
+        if p.method == "POST" and p.path == "/run_strategy":
+            return run_strategy_api(RunStrategyRequest(**body))
+
+        return JSONResponse(status_code=400, content={"error": f"Unsupported preset path: {p.path}"})
+    except Exception as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
 
 
 # Health check endpoint

--- a/server/models.py
+++ b/server/models.py
@@ -5,6 +5,29 @@ from typing import Any, Dict, List, Optional, Literal
 
 from pydantic import BaseModel, Field
 
+
+class PresetInfo(BaseModel):
+    name: str
+    description: str
+    method: Literal["GET", "POST"]
+    path: str
+
+
+class PresetDetail(PresetInfo):
+    default_body: Optional[Dict[str, Any]] = None
+    default_params: Optional[Dict[str, Any]] = None
+
+
+class PresetExecuteRequest(BaseModel):
+    name: str = Field(description="Preset name, e.g., 'summary_default_btc_1h_4h'")
+    overrides_body: Optional[Dict[str, Any]] = Field(
+        default=None, description="Partial overrides merged into default body"
+    )
+    overrides_params: Optional[Dict[str, Any]] = Field(
+        default=None, description="Partial overrides merged into default params"
+    )
+
+
 SignalSide = Literal["long", "short", "neutral"]
 
 

--- a/server/presets.py
+++ b/server/presets.py
@@ -1,0 +1,112 @@
+from typing import Any, Dict, Literal, Optional, Callable, Tuple
+
+Method = Literal["GET", "POST"]
+
+
+class Preset:
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        method: Method,
+        path: str,
+        default_body: Optional[Dict[str, Any]] = None,
+        default_params: Optional[Dict[str, Any]] = None,
+        execute_fn: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    ):
+        self.name = name
+        self.description = description
+        self.method = method
+        self.path = path
+        self.default_body = default_body or {}
+        self.default_params = default_params or {}
+        self.execute_fn = execute_fn
+
+
+PRESETS: Dict[str, Preset] = {}
+
+
+def _add(p: Preset) -> None:
+    PRESETS[p.name] = p
+
+
+_add(
+    Preset(
+        name="summary_default_btc_1h_4h",
+        description="Multi-timeframe summary (1h vs 4h) for BTC on Binance.US with default RSI/MACD/Bollinger settings.",
+        method="POST",
+        path="/summary_signal",
+        default_body={
+            "symbol": "BTC/USDT",
+            "exchange": "binanceus",
+            "resolutions": {"short_term": "1h", "long_term": "4h"},
+            "indicators": {
+                "rsi": {"window": 14},
+                "macd": {"fast": 12, "slow": 26, "signal": 9},
+                "bollinger": {"window": 20, "std_dev": 2},
+            },
+            "limit": 200,
+        },
+    )
+)
+
+_add(
+    Preset(
+        name="indicators_btc_1h_default",
+        description="Compute RSI(14), MACD(12,26,9), Bollinger(20,2) for BTC 1h on Binance.US.",
+        method="POST",
+        path="/compute_indicators",
+        default_body={
+            "symbol": "BTC/USDT",
+            "exchange": "binanceus",
+            "resolution": "1h",
+            "indicators": {
+                "rsi": {"window": 14},
+                "macd": {"fast": 12, "slow": 26, "signal": 9},
+                "bollinger": {"window": 20, "std_dev": 2},
+            },
+            "limit": 200,
+        },
+    )
+)
+
+_add(
+    Preset(
+        name="ema_crossover_btc_1h",
+        description="EMA crossover (12/26) strategy for BTC 1h on Binance.US.",
+        method="POST",
+        path="/run_strategy",
+        default_body={
+            "symbol": "BTC/USDT",
+            "exchange": "binanceus",
+            "resolution": "1h",
+            "limit": 500,
+            "config": {"strategy": "ema_crossover", "short_window": 12, "long_window": 26},
+        },
+    )
+)
+
+_add(
+    Preset(
+        name="ohlcv_btc_1h_200",
+        description="Fetch last 200 BTC/USDT 1h candles from Binance.US.",
+        method="GET",
+        path="/ohlcv",
+        default_params={
+            "symbol": "BTC/USDT",
+            "exchange": "binanceus",
+            "resolution": "1h",
+            "limit": 200,
+        },
+    )
+)
+
+_add(
+    Preset(
+        name="news_default",
+        description="Fetch recent crypto headlines (CryptoPanic).",
+        method="GET",
+        path="/news",
+    )
+)
+


### PR DESCRIPTION
## Summary
- add server-side preset registry with five default crypto analysis presets
- expose `/presets`, `/presets/{name}`, and `/presets/execute` endpoints for listing, inspecting, and executing presets
- support execution overrides and internal routing to existing summary, indicator, strategy, OHLCV, and news functions

## Testing
- `pytest -q`
- `curl -s http://localhost:8000/presets -H "x-api-key: $API_KEY" | jq .`
- `curl -s http://localhost:8000/presets/summary_default_btc_1h_4h -H "x-api-key: $API_KEY" | jq .`
- `curl -s -X POST http://localhost:8000/presets/execute -H "Content-Type: application/json" -H "x-api-key: $API_KEY" -d '{"name":"summary_default_btc_1h_4h"}' | jq .` *(fails: Error fetching data from binanceus)*
- `curl -s -X POST http://localhost:8000/presets/execute -H "Content-Type: application/json" -H "x-api-key: $API_KEY" -d '{"name":"ohlcv_btc_1h_200","overrides_params":{"limit":5}}' | jq .` *(fails: Error fetching data from binanceus)*

------
https://chatgpt.com/codex/tasks/task_e_68993fb9bd60832896587c5c1e15bff9