### PR TITLE
Add example responses and response models

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -20,7 +20,10 @@ from .models import (
     ComputeIndicatorsResponse,
     RunStrategyRequest,
     RunStrategyResponse,
+    StrategyRow,
     OhlcvResponse,
+    OhlcvRow,
+    NewsResponse,
     PresetInfo,
     PresetDetail,
     PresetExecuteRequest,
@@ -199,18 +202,31 @@ def summary_signal(req: SummarySignalRequest):
                 results[name] = timeframe_summary(df, req.indicators, debug=debug)
         return replace_nans(results)
     except Exception as e:
-        return {"error": str(e)}
+        return JSONResponse(status_code=400, content={"error": str(e)})
 
 
-@app.get("/news", dependencies=[Depends(verify_api_key)])
+@app.get(
+    "/news",
+    response_model=NewsResponse,
+    dependencies=[Depends(verify_api_key)],
+)
 def get_news():
-    """
-    Fetch recent crypto headlines from CryptoPanic (up to 20). Each item includes source, title, url, published_at, and tags.
-    """
+    """Fetch recent crypto headlines from CryptoPanic."""
     try:
-        return fetch_latest_news(20)
+        news_list = fetch_latest_news(20)
+        items = [
+            {
+                "source": i["source"],
+                "title": i["title"],
+                "url": i["url"],
+                "published_at": i["published_at"],
+                "tags": i.get("tags", []),
+            }
+            for i in news_list
+        ]
+        return {"items": items}
     except Exception as e:
-        return {"error": str(e)}
+        return JSONResponse(status_code=400, content={"error": str(e)})
 
 
 @app.post(
@@ -239,7 +255,7 @@ def compute_indicators_api(req: ComputeIndicatorsRequest):
         }
 
     except Exception as e:
-        return {"error": str(e)}
+        return JSONResponse(status_code=400, content={"error": str(e)})
 
 
 # Preset routes
@@ -363,7 +379,7 @@ def ohlcv(symbol: str, exchange: str, resolution: str = "1h", limit: int = 200):
         rows = replace_nans(rows)
         return {"rows": rows}
     except Exception as e:
-        return {"error": str(e)}
+        return JSONResponse(status_code=400, content={"error": str(e)})
 
 
 

--- a/server/models.py
+++ b/server/models.py
@@ -1,54 +1,42 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any, Dict, List, Optional, Literal
+from datetime import datetime
 
 from pydantic import BaseModel, Field
-
-
-class PresetInfo(BaseModel):
-    name: str
-    description: str
-    method: Literal["GET", "POST"]
-    path: str
-
-
-class PresetDetail(PresetInfo):
-    default_body: Optional[Dict[str, Any]] = None
-    default_params: Optional[Dict[str, Any]] = None
-
-
-class PresetExecuteRequest(BaseModel):
-    name: str = Field(description="Preset name, e.g., 'summary_default_btc_1h_4h'")
-    overrides_body: Optional[Dict[str, Any]] = Field(
-        default=None, description="Partial overrides merged into default body"
-    )
-    overrides_params: Optional[Dict[str, Any]] = Field(
-        default=None, description="Partial overrides merged into default params"
-    )
-
 
 SignalSide = Literal["long", "short", "neutral"]
 
 
+# ---------- Summary Signal ----------
+
 class Detail(BaseModel):
-    method: str
-    signal: SignalSide
-    confidence: float = Field(ge=0, le=1)
+    method: str = Field(..., example="MACD")
+    signal: SignalSide = Field(..., example="long")
+    confidence: float = Field(..., ge=0, le=1, example=0.78)
 
 
 class Block(BaseModel):
-    summary: SignalSide
-    confidence: float = Field(ge=0, le=1)
+    summary: SignalSide = Field(..., example="long")
+    confidence: float = Field(..., ge=0, le=1, example=0.76)
     details: List[Detail]
 
 
 class SummarySignalRequest(BaseModel):
-    symbol: str
-    exchange: str
-    resolutions: Dict[str, str]
-    indicators: Dict[str, Any]
-    limit: int = 200
+    symbol: str = Field(..., example="BTC/USDT")
+    exchange: str = Field(..., example="binanceus")
+    resolutions: Dict[str, str] = Field(
+        ..., example={"short_term": "1h", "long_term": "4h"}
+    )
+    indicators: Dict[str, Any] = Field(
+        ...,
+        example={
+            "rsi": {"window": 14},
+            "macd": {"fast": 12, "slow": 26, "signal": 9},
+            "bollinger": {"window": 20, "std_dev": 2},
+        },
+    )
+    limit: int = Field(200, example=200)
 
 
 class SummarySignalResponse(BaseModel):
@@ -60,18 +48,20 @@ class SummarySignalResponse(BaseModel):
             "example": {
                 "short_term": {
                     "summary": "long",
-                    "confidence": 0.8,
+                    "confidence": 0.78,
                     "details": [
-                        {"method": "RSI", "signal": "long", "confidence": 0.9},
-                        {"method": "MACD", "signal": "neutral", "confidence": 0.5},
+                        {"method": "MACD", "signal": "long", "confidence": 0.82},
+                        {"method": "RSI", "signal": "neutral", "confidence": 0.50},
+                        {"method": "Bollinger", "signal": "neutral", "confidence": 0.60},
                     ],
                 },
                 "long_term": {
-                    "summary": "short",
-                    "confidence": 0.6,
+                    "summary": "neutral",
+                    "confidence": 0.52,
                     "details": [
-                        {"method": "RSI", "signal": "short", "confidence": 0.7},
-                        {"method": "Bollinger", "signal": "short", "confidence": 0.5},
+                        {"method": "MACD", "signal": "neutral", "confidence": 0.55},
+                        {"method": "RSI", "signal": "neutral", "confidence": 0.50},
+                        {"method": "Bollinger", "signal": "short", "confidence": 0.58},
                     ],
                 },
             }
@@ -79,13 +69,7 @@ class SummarySignalResponse(BaseModel):
     }
 
 
-class ComputeIndicatorsRequest(BaseModel):
-    symbol: str
-    exchange: str
-    resolution: str
-    indicators: Dict[str, Any]
-    limit: int = 200
-
+# ---------- Compute Indicators ----------
 
 class MACDSeries(BaseModel):
     macd_line: List[Optional[float]]
@@ -99,9 +83,24 @@ class BollingerSeries(BaseModel):
     lower: List[Optional[float]]
 
 
+class ComputeIndicatorsRequest(BaseModel):
+    symbol: str = Field(..., example="BTC/USDT")
+    exchange: str = Field(..., example="binanceus")
+    resolution: str = Field(..., example="1h")
+    indicators: Dict[str, Any] = Field(
+        ...,
+        example={
+            "rsi": {"window": 14},
+            "macd": {"fast": 12, "slow": 26, "signal": 9},
+            "bollinger": {"window": 20, "std_dev": 2},
+        },
+    )
+    limit: int = Field(200, example=200)
+
+
 class ComputeIndicatorsResponse(BaseModel):
-    symbol: str
-    exchange: str
+    symbol: str = Field(..., example="BTC/USDT")
+    exchange: str = Field(..., example="binanceus")
     indicators: Dict[str, Any]
 
     model_config = {
@@ -110,15 +109,16 @@ class ComputeIndicatorsResponse(BaseModel):
                 "symbol": "BTC/USDT",
                 "exchange": "binanceus",
                 "indicators": {
+                    "rsi": [None, None, 32.1, 45.3, 51.8],
                     "macd": {
-                        "macd_line": [0.1, 0.2],
-                        "signal_line": [0.05, 0.1],
-                        "histogram": [0.05, 0.1],
+                        "macd_line": [None, -22.5, -10.1, 3.4, 9.2],
+                        "signal_line": [None, -18.2, -8.0, 1.2, 6.5],
+                        "histogram": [None, -4.3, -2.1, 2.2, 2.7],
                     },
                     "bollinger": {
-                        "upper": [100.0, 101.0],
-                        "mid": [99.0, 100.0],
-                        "lower": [98.0, 99.0],
+                        "upper": [None, None, 118500.1, 118620.4, 118740.9],
+                        "mid": [None, None, 117900.0, 118010.2, 118120.0],
+                        "lower": [None, None, 117300.2, 117399.9, 117499.1],
                     },
                 },
             }
@@ -126,26 +126,32 @@ class ComputeIndicatorsResponse(BaseModel):
     }
 
 
-class RunStrategyRequest(BaseModel):
-    symbol: Optional[str] = None
-    exchange: Optional[str] = None
-    resolution: str = "1h"
-    limit: int = 500
-    config: Dict[str, Any]
-    filepath: Optional[str] = None
-
+# ---------- Run Strategy (EMA crossover) ----------
 
 class StrategyRow(BaseModel):
-    Date: datetime
-    Open: float
-    High: float
-    Low: float
-    Close: float
-    Volume: float
-    Signal: SignalSide
-    EMA_short: Optional[float] = None
-    EMA_long: Optional[float] = None
-    Crossover: Optional[Literal["bullish", "bearish", "none"]] = "none"
+    Date: datetime = Field(..., example="2025-07-23T12:00:00Z")
+    Open: float = Field(..., example=118512.24)
+    High: float = Field(..., example=118653.81)
+    Low: float = Field(..., example=117775.02)
+    Close: float = Field(..., example=117782.88)
+    Volume: float = Field(..., example=0.89481)
+    Signal: SignalSide = Field(..., example="long")
+    EMA_short: Optional[float] = Field(None, example=118120.5)
+    EMA_long: Optional[float] = Field(None, example=118040.2)
+    Crossover: Optional[Literal["bullish", "bearish", "none"]] = Field(
+        "none", example="bullish"
+    )
+
+
+class RunStrategyRequest(BaseModel):
+    symbol: Optional[str] = Field(None, example="BTC/USDT")
+    exchange: Optional[str] = Field(None, example="binanceus")
+    resolution: str = Field("1h", example="1h")
+    limit: int = Field(500, example=500)
+    config: Dict[str, Any] = Field(
+        ..., example={"strategy": "ema_crossover", "short_window": 12, "long_window": 26}
+    )
+    filepath: Optional[str] = Field(None, example="/path/to/local.csv")
 
 
 class RunStrategyResponse(BaseModel):
@@ -156,28 +162,40 @@ class RunStrategyResponse(BaseModel):
             "example": {
                 "rows": [
                     {
-                        "Date": "2024-01-01T00:00:00Z",
-                        "Open": 100.0,
-                        "High": 105.0,
-                        "Low": 99.0,
-                        "Close": 102.0,
-                        "Volume": 1234.5,
+                        "Date": "2025-07-23T10:00:00Z",
+                        "Open": 118026.49,
+                        "High": 118667.70,
+                        "Low": 117893.42,
+                        "Close": 118427.30,
+                        "Volume": 2.21387,
+                        "Signal": "neutral",
+                        "EMA_short": 118180.1,
+                        "EMA_long": 118120.7,
+                        "Crossover": "none",
+                    },
+                    {
+                        "Date": "2025-07-23T11:00:00Z",
+                        "Open": 118383.81,
+                        "High": 118667.66,
+                        "Low": 118258.49,
+                        "Close": 118508.27,
+                        "Volume": 0.36994,
                         "Signal": "long",
-                        "EMA_short": 101.0,
-                        "EMA_long": 100.5,
+                        "EMA_short": 118220.4,
+                        "EMA_long": 118140.2,
                         "Crossover": "bullish",
                     },
                     {
-                        "Date": "2024-01-01T01:00:00Z",
-                        "Open": 102.0,
-                        "High": 106.0,
-                        "Low": 101.0,
-                        "Close": 104.0,
-                        "Volume": 1300.0,
-                        "Signal": "neutral",
-                        "EMA_short": 102.0,
-                        "EMA_long": 101.0,
-                        "Crossover": "none",
+                        "Date": "2025-07-23T12:00:00Z",
+                        "Open": 118512.24,
+                        "High": 118653.81,
+                        "Low": 117775.02,
+                        "Close": 117782.88,
+                        "Volume": 0.89481,
+                        "Signal": "short",
+                        "EMA_short": 118150.2,
+                        "EMA_long": 118160.9,
+                        "Crossover": "bearish",
                     },
                 ]
             }
@@ -185,13 +203,15 @@ class RunStrategyResponse(BaseModel):
     }
 
 
+# ---------- OHLCV ----------
+
 class OhlcvRow(BaseModel):
-    Date: datetime
-    Open: float
-    High: float
-    Low: float
-    Close: float
-    Volume: float
+    Date: datetime = Field(..., example="2025-07-23T14:00:00Z")
+    Open: float = Field(..., example=117400.00)
+    High: float = Field(..., example=118045.45)
+    Low: float = Field(..., example=117395.17)
+    Close: float = Field(..., example=118045.45)
+    Volume: float = Field(..., example=0.17734)
 
 
 class OhlcvResponse(BaseModel):
@@ -202,22 +222,163 @@ class OhlcvResponse(BaseModel):
             "example": {
                 "rows": [
                     {
-                        "Date": "2024-01-01T00:00:00Z",
-                        "Open": 100.0,
-                        "High": 105.0,
-                        "Low": 99.0,
-                        "Close": 102.0,
-                        "Volume": 1234.5,
+                        "Date": "2025-07-23T12:00:00Z",
+                        "Open": 118512.24,
+                        "High": 118653.81,
+                        "Low": 117775.02,
+                        "Close": 117782.88,
+                        "Volume": 0.89481,
                     },
                     {
-                        "Date": "2024-01-01T01:00:00Z",
-                        "Open": 102.0,
-                        "High": 106.0,
-                        "Low": 101.0,
-                        "Close": 104.0,
-                        "Volume": 1300.0,
+                        "Date": "2025-07-23T13:00:00Z",
+                        "Open": 117929.37,
+                        "High": 118191.86,
+                        "Low": 117362.00,
+                        "Close": 117494.54,
+                        "Volume": 1.12609,
+                    },
+                    {
+                        "Date": "2025-07-23T14:00:00Z",
+                        "Open": 117400.00,
+                        "High": 118045.45,
+                        "Low": 117395.17,
+                        "Close": 118045.45,
+                        "Volume": 0.17734,
                     },
                 ]
+            }
+        }
+    }
+
+
+# ---------- News (CryptoPanic) ----------
+
+class NewsItem(BaseModel):
+    source: str = Field(..., example="CoinDesk")
+    title: str = Field(..., example="Bitcoin Surges as Spot ETFs See Record Inflows")
+    url: str = Field(..., example="https://example.com/article")
+    published_at: datetime = Field(..., example="2025-07-23T14:05:00Z")
+    tags: List[str] = Field(default_factory=list, example=["BTC", "ETF", "Market"])
+
+
+class NewsResponse(BaseModel):
+    items: List[NewsItem]
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "items": [
+                    {
+                        "source": "CoinDesk",
+                        "title": "Bitcoin Surges as Spot ETFs See Record Inflows",
+                        "url": "https://example.com/article",
+                        "published_at": "2025-07-23T14:05:00Z",
+                        "tags": ["BTC", "ETF", "Market"],
+                    },
+                    {
+                        "source": "The Block",
+                        "title": "Altcoins Follow BTC Higher Amid Broader Risk Rally",
+                        "url": "https://example.com/altcoins",
+                        "published_at": "2025-07-23T13:45:00Z",
+                        "tags": ["ETH", "ALT", "Sentiment"],
+                    },
+                ]
+            }
+        }
+    }
+
+
+# ---------- Presets (from Task C) ----------
+
+class PresetInfo(BaseModel):
+    name: str = Field(..., example="summary_default_btc_1h_4h")
+    description: str = Field(
+        ..., example="Multi-timeframe summary (1h vs 4h) for BTC on Binance.US with default RSI/MACD/Bollinger settings."
+    )
+    method: Literal["GET", "POST"] = Field(..., example="POST")
+    path: str = Field(..., example="/summary_signal")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "name": "summary_default_btc_1h_4h",
+                "description": "Multi-timeframe summary (1h vs 4h) for BTC on Binance.US with default RSI/MACD/Bollinger settings.",
+                "method": "POST",
+                "path": "/summary_signal",
+            }
+        }
+    }
+
+
+class PresetDetail(PresetInfo):
+    default_body: Optional[Dict[str, Any]] = Field(
+        None,
+        example={
+            "symbol": "BTC/USDT",
+            "exchange": "binanceus",
+            "resolutions": {"short_term": "1h", "long_term": "4h"},
+            "indicators": {
+                "rsi": {"window": 14},
+                "macd": {"fast": 12, "slow": 26, "signal": 9},
+                "bollinger": {"window": 20, "std_dev": 2},
+            },
+            "limit": 200,
+        },
+    )
+    default_params: Optional[Dict[str, Any]] = Field(
+        None,
+        example={
+            "symbol": "BTC/USDT",
+            "exchange": "binanceus",
+            "resolution": "1h",
+            "limit": 200,
+        },
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "name": "summary_default_btc_1h_4h",
+                "description": "Multi-timeframe summary (1h vs 4h) for BTC on Binance.US with default RSI/MACD/Bollinger settings.",
+                "method": "POST",
+                "path": "/summary_signal",
+                "default_body": {
+                    "symbol": "BTC/USDT",
+                    "exchange": "binanceus",
+                    "resolutions": {"short_term": "1h", "long_term": "4h"},
+                    "indicators": {
+                        "rsi": {"window": 14},
+                        "macd": {"fast": 12, "slow": 26, "signal": 9},
+                        "bollinger": {"window": 20, "std_dev": 2},
+                    },
+                    "limit": 200,
+                },
+                "default_params": {
+                    "symbol": "BTC/USDT",
+                    "exchange": "binanceus",
+                    "resolution": "1h",
+                    "limit": 200,
+                },
+            }
+        }
+    }
+
+
+class PresetExecuteRequest(BaseModel):
+    name: str = Field(..., example="summary_default_btc_1h_4h")
+    overrides_body: Optional[Dict[str, Any]] = Field(
+        default=None, example={"exchange": "coinbase", "symbol": "BTC/USD"}
+    )
+    overrides_params: Optional[Dict[str, Any]] = Field(
+        default=None, example={"limit": 50}
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "name": "summary_default_btc_1h_4h",
+                "overrides_body": {"exchange": "coinbase", "symbol": "BTC/USD"},
+                "overrides_params": {"limit": 50},
             }
         }
     }


### PR DESCRIPTION
## Summary
- define detailed Pydantic models with realistic example responses for signals, indicators, strategies, OHLCV data, news, and presets
- attach `response_model` to API routes and convert `/news` output to structured items
- standardize error handling with JSON responses across endpoints

## Testing
- `pytest -q`
- `curl -s -X POST http://localhost:8000/summary_signal -H "Content-Type: application/json" -H "x-api-key: $API_KEY" -d '{"symbol":"BTC/USDT","exchange":"binanceus","resolutions":{"short_term":"1h","long_term":"4h"},"indicators":{"rsi":{"window":14},"macd":{"fast":12,"slow":26,"signal":9},"bollinger":{"window":20,"std_dev":2}},"limit":200}'`
- `curl -s http://localhost:8000/news -H "x-api-key: $API_KEY"`


------
https://chatgpt.com/codex/tasks/task_e_68994223d8488328a2e2922d3de64471