### PR TITLE
Data Proxy + GPT TA Analysis (foundations)

### DIFF
--- a/.github/workflows/data_proxy.yml
+++ b/.github/workflows/data_proxy.yml
@@ -1,0 +1,18 @@
+name: Data Proxy CI
+
+on:
+  push:
+    branches: [ feature/data-proxy-gpt-analysis ]
+  pull_request:
+    branches: [ feature/data-proxy-gpt-analysis ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r services/data_proxy/requirements.txt
+      - run: pytest services/data_proxy/tests

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ server/__pycache__
 ta_engine/__pycache__
 core/indicators/__pycache__
 .env
-logs/
+logs
+.venv/
+__pycache__/

--- a/gpts/ta_analyst/examples/eth_kraken_4h_1d.md
+++ b/gpts/ta_analyst/examples/eth_kraken_4h_1d.md
@@ -1,0 +1,35 @@
+### Example: ETH/USDC on Kraken (4h & 1d)
+
+**Tool calls**
+1. `GET /ohlcv?symbol=ETH/USDC&exchange=kraken&timeframe=4h&limit=1000`
+2. `GET /ohlcv?symbol=ETH/USDC&exchange=kraken&timeframe=1d&limit=1000`
+3. `POST /indicators` with body `{ "symbol":"ETH/USDC", "exchange":"kraken", "timeframe":"4h", "inputs":{"rsi":{},"macd":{},"bb":{},"ema":[20,50,200],"atr":{},"adx":{}} }`
+4. `GET /cryptopanic?asset=ETH`
+5. `GET /reddit/search?subreddits=ethtrader,ethereum`
+
+**Summary**
+Market is in placeholder uptrend; sentiment mixed.
+
+```json
+{
+  "as_of":"2024-01-01T00:00:00Z",
+  "asset":"ETH/USDC",
+  "exchange":"kraken",
+  "timeframes":["4h","1d"],
+  "market_state":{
+    "trend":{"4h":"up","1d":"up"},
+    "volatility_regime":{},
+    "structure":{}
+  },
+  "indicators":{
+    "rsi":55.0,
+    "macd":{"macd":1.0,"signal":0.5,"hist":0.5},
+    "bb":{"lower":1000.0,"basis":1100.0,"upper":1200.0},
+    "ema":{"20":1100.0,"50":1050.0,"200":900.0},
+    "atr":10.0,
+    "adx":20.0
+  },
+  "sentiment":{"cryptopanic":[],"reddit":[]},
+  "outlook":{"short_term":{"if":"price holds above 1100","then":"target 1200","confidence":0.6},"long_term":{"if":"price breaks 1300","then":"target 1500","confidence":0.5}}
+}
+```

--- a/gpts/ta_analyst/instructions.md
+++ b/gpts/ta_analyst/instructions.md
@@ -1,0 +1,7 @@
+System rules (concise):
+- Never fabricate values; only use tool outputs.
+- Default TFs: 4h & 1d unless specified.
+- Prefer /indicators for RSI/MACD/BB/EMA/ATR/ADX; you may compute simple deltas/levels yourself.
+- Pull CryptoPanic + Reddit; summarize topics; describe the heuristic for sentiment briefly.
+- Output: 1) concise human summary, 2) strict JSON (see schema).
+- Provide short-term and long-term outlook with scenario “if/then” and confidence 0–1.

--- a/gpts/ta_analyst/schema.json
+++ b/gpts/ta_analyst/schema.json
@@ -1,0 +1,21 @@
+{
+  "type":"object",
+  "required":["as_of","asset","exchange","timeframes","market_state","indicators","sentiment","outlook"],
+  "properties":{
+    "as_of":{"type":"string"},
+    "asset":{"type":"string"},
+    "exchange":{"type":"string"},
+    "timeframes":{"type":"array","items":{"type":"string"}},
+    "market_state":{
+      "type":"object",
+      "properties":{
+        "trend":{"type":"object"},
+        "volatility_regime":{"type":"object"},
+        "structure":{"type":"object"}
+      }
+    },
+    "indicators":{"type":"object"},
+    "sentiment":{"type":"object"},
+    "outlook":{"type":"object"}
+  }
+}

--- a/gpts/ta_analyst/tools.json
+++ b/gpts/ta_analyst/tools.json
@@ -1,0 +1,3 @@
+[
+  {"name":"TA Data Proxy","type":"openapi","url":"http://localhost:8001/openapi.json","auth":"none"}
+]

--- a/scripts/run_daily_analysis.py
+++ b/scripts/run_daily_analysis.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+import argparse
+import datetime as dt
+from pathlib import Path
+
+# from openai import OpenAI
+
+
+def run(args):
+    date = dt.date.today().isoformat()
+    outdir = Path("reports") / date
+    outdir.mkdir(parents=True, exist_ok=True)
+    for asset in args.assets.split(","):
+        fname_base = f"{asset}-{args.exchange}"
+        (outdir / f"{fname_base}.json").write_text("{}")
+        (outdir / f"{fname_base}.md").write_text("TODO: call GPT and render report")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--assets", required=True, help="Comma separated list, e.g. ETH/USDC,BTC/USDT")
+    parser.add_argument("--exchange", required=True)
+    parser.add_argument("--timeframes", default="4h,1d")
+    args = parser.parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/data_proxy/.env.sample
+++ b/services/data_proxy/.env.sample
@@ -1,0 +1,5 @@
+# if you add keys later (reddit/cryptopanic), document them here
+# CRYPTOPANIC_KEY=
+# REDDIT_CLIENT_ID=
+# REDDIT_SECRET=
+# REDDIT_USER_AGENT=

--- a/services/data_proxy/README.md
+++ b/services/data_proxy/README.md
@@ -1,0 +1,3 @@
+uvicorn app.main:app --reload --port 8001
+# GET http://localhost:8001/health
+# GET http://localhost:8001/ohlcv?symbol=ETH/USDC&exchange=kraken&timeframe=4h&limit=1000

--- a/services/data_proxy/app/main.py
+++ b/services/data_proxy/app/main.py
@@ -1,0 +1,102 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import pandas as pd
+import os, time
+import ccxt
+import pandas_ta as ta
+
+app = FastAPI(title="TA Data Proxy", version="0.1.0")
+
+EXCHANGES = {}
+
+def get_exchange(name: str):
+    name = name.lower()
+    if name not in EXCHANGES:
+        if name == "binanceus":
+            EXCHANGES[name] = ccxt.binanceus()
+        elif name == "kraken":
+            EXCHANGES[name] = ccxt.kraken()
+        else:
+            raise HTTPException(400, f"Unsupported exchange '{name}'")
+    return EXCHANGES[name]
+
+def ohlcv_df(exchange: str, symbol: str, timeframe: str, limit: int = 1000) -> pd.DataFrame:
+    ex = get_exchange(exchange)
+    data = ex.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+    if not data:
+        raise HTTPException(404, "No OHLCV returned")
+    df = pd.DataFrame(data, columns=["ts","open","high","low","close","volume"])
+    df["ts"] = pd.to_datetime(df["ts"], unit="ms", utc=True)
+    return df
+
+@app.get("/health")
+def health():
+    return {"ok": True, "time": int(time.time())}
+
+@app.get("/ohlcv")
+def get_ohlcv(symbol: str, exchange: str, timeframe: str, limit: int = 1000):
+    df = ohlcv_df(exchange, symbol, timeframe, limit)
+    return {"candles": df.to_dict(orient="records")}
+
+class IndicatorInputs(BaseModel):
+    symbol: str
+    exchange: str
+    timeframe: str
+    inputs: dict = {}
+
+@app.post("/indicators")
+def post_indicators(body: IndicatorInputs):
+    df = ohlcv_df(body.exchange, body.symbol, body.timeframe, 2000)
+    out = {}
+    inp = body.inputs or {}
+
+    # RSI
+    if "rsi" in inp:
+        L = int(inp["rsi"].get("length", 14))
+        out["rsi"] = float(ta.rsi(df["close"], length=L).iloc[-1])
+
+    # MACD
+    if "macd" in inp:
+        p = inp["macd"]; f=p.get("fast",12); s=p.get("slow",26); sig=p.get("signal",9)
+        macd = ta.macd(df["close"], fast=f, slow=s, signal=sig).iloc[-1].to_dict()
+        out["macd"] = {
+            "macd": float(macd.get(f"MACD_{f}_{s}_{sig}")),
+            "signal": float(macd.get(f"MACDs_{f}_{s}_{sig}")),
+            "hist": float(macd.get(f"MACDh_{f}_{s}_{sig}"))
+        }
+
+    # Bollinger Bands
+    if "bb" in inp:
+        l = inp["bb"].get("length",20); sd = inp["bb"].get("stdev",2)
+        bb = ta.bbands(df["close"], length=l, std=sd).iloc[-1].to_dict()
+        out["bb"] = {
+            "lower": float(bb.get(f"BBL_{l}_{sd}.0")),
+            "basis": float(bb.get(f"BBM_{l}_{sd}.0")),
+            "upper": float(bb.get(f"BBU_{l}_{sd}.0"))
+        }
+
+    # EMA (array)
+    if "ema" in inp:
+        out["ema"] = {str(n): float(ta.ema(df["close"], length=int(n)).iloc[-1]) for n in inp["ema"]}
+
+    # ATR
+    if "atr" in inp:
+        L = int(inp["atr"].get("length",14))
+        out["atr"] = float(ta.atr(df["high"], df["low"], df["close"], length=L).iloc[-1])
+
+    # ADX
+    if "adx" in inp:
+        L = int(inp["adx"].get("length",14))
+        out["adx"] = float(ta.adx(df["high"], df["low"], df["close"], length=L)[f"ADX_{L}"].iloc[-1])
+
+    return {"as_of": df["ts"].iloc[-1].isoformat(), "values": out}
+
+@app.get("/cryptopanic")
+def get_cryptopanic(asset: str, lookback_days: int = 3):
+    # TODO: wire to existing CryptoPanic integration
+    return {"items": []}
+
+@app.get("/reddit/search")
+def reddit_search(subreddits: str, query: str = "", lookback_hours: int = 48, limit: int = 100):
+    # TODO: wire to Reddit worker/API
+    return {"posts": [], "comments": []}

--- a/services/data_proxy/openapi.yaml
+++ b/services/data_proxy/openapi.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.3
+info: { title: TA Data Proxy, version: '0.1.0' }
+paths:
+  /ohlcv:
+    get:
+      summary: Get OHLCV
+      parameters:
+        - { in: query, name: symbol, required: true, schema: { type: string } }
+        - { in: query, name: exchange, required: true, schema: { type: string } }
+        - { in: query, name: timeframe, required: true, schema: { type: string } }
+        - { in: query, name: limit, required: false, schema: { type: integer, default: 1000 } }
+      responses:
+        '200': { description: OK }
+  /indicators:
+    post:
+      summary: Compute indicators over OHLCV
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                symbol: { type: string }
+                exchange: { type: string }
+                timeframe: { type: string }
+                inputs: { type: object }
+      responses:
+        '200': { description: OK }
+  /cryptopanic:
+    get:
+      summary: CryptoPanic news
+      parameters:
+        - { in: query, name: asset, required: true, schema: { type: string } }
+        - { in: query, name: lookback_days, required: false, schema: { type: integer, default: 3 } }
+      responses:
+        '200': { description: OK }
+  /reddit/search:
+    get:
+      summary: Reddit search
+      parameters:
+        - { in: query, name: subreddits, required: true, schema: { type: string } }
+        - { in: query, name: query, required: false, schema: { type: string } }
+        - { in: query, name: lookback_hours, required: false, schema: { type: integer, default: 48 } }
+        - { in: query, name: limit, required: false, schema: { type: integer, default: 100 } }
+      responses:
+        '200': { description: OK }

--- a/services/data_proxy/requirements.txt
+++ b/services/data_proxy/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+ccxt
+pandas
+pandas_ta
+python-dateutil
+numpy<2

--- a/services/data_proxy/tests/test_smoke.py
+++ b/services/data_proxy/tests/test_smoke.py
@@ -1,0 +1,3 @@
+
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- scaffold FastAPI service exposing OHLCV and TA indicators
- add TA analyst GPT pack with examples and tool definition
- provide stub CLI runner and CI workflow

## Testing
- `uvicorn main:app --port 8001 --app-dir services/data_proxy/app`
- `curl http://127.0.0.1:8001/health`
- `curl "http://127.0.0.1:8001/ohlcv?symbol=ETH/USDC&exchange=kraken&timeframe=4h&limit=5"` *(fails: Network is unreachable)*
- `curl http://127.0.0.1:8001/cryptopanic?asset=ETH`
- `curl "http://127.0.0.1:8001/reddit/search?subreddits=ethtrader&query=eth"`
- `pytest services/data_proxy/tests/test_smoke.py -q`

## Next steps
- [ ] Wire CryptoPanic integration
- [ ] Back Reddit search with ingest worker and DB


------
https://chatgpt.com/codex/tasks/task_e_689b6655a9288328a0390353486d3d5a